### PR TITLE
Sample json

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ INSTALL_REQUIREMENTS = list( read_reqs(CURRENT_DIR / "requirements.txt") )
 
 SETUP = dict(
     name="iec62209",
-    version="1.0.6",
+    version="1.0.7",
     description="Publication-IEC62209 package",
     author=", ".join(
         (

--- a/src/iec62209/sample.py
+++ b/src/iec62209/sample.py
@@ -31,12 +31,12 @@ class Sample:
             xmax = 0
             xsup = 0
             if 'x' in df:
-                xmax = df['x'].abs().max()
+                xmax = int(df['x'].abs().max())
                 xsup = math.ceil(xmax * mult)
             ymax = 0
             ysup = 0
             if 'y' in df:
-                ymax = df['y'].abs().max()
+                ymax = int(df['y'].abs().max())
                 ysup = math.ceil(ymax * mult)
             self.mdata = {'xmax':xmax, 'xsup':xsup, 'ymax':ymax, 'ysup':ysup}
 


### PR DESCRIPTION
numpy data types are not JSON-serializable, so we convert all sample metadata to int (now they all have the same type)